### PR TITLE
mouseenter event didn't update scrollbar

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -49,7 +49,9 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
       }
 
       // This is necessary when you don't watch anything with the scrollbar
-      $elem.bind('mouseenter', update('mouseenter'));
+      $elem.bind('mouseenter', function() {
+        update('mouseenter'));
+      });
 
       // Possible future improvement - check the type here and use the appropriate watch for non-arrays
       if ($attr.refreshOnChange) {


### PR DESCRIPTION
The mouse enter event didn't trigger the update function. 
The scrollbar initialized fine, but didn't show up when trying to select it.
The problem seems to be that jQuery's `bind` requires a handler **function**.
